### PR TITLE
Omit use_batching and clarify units

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,7 +13,6 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' @param scale_factor Scale factor for the activity samples.
 #' @param sample_rate sampling rate for activity samples.
 #' @param start_time starting time of the sample recording.
-#' @param use_batching whether to use batching or not (false by default)
 #' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
 #' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 #' @param verbose Print the parameters from the log.bin file and other messages?
@@ -25,8 +24,8 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' The matrix has attributes
 #' "time_index", "missingness", "start_time_log", "sample_rate", "impute_zeroes".
 #'
-parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, use_batching = FALSE, batch_begin = 0L, batch_end = 0L, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
-    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes)
+parseGT3X <- function(filename, max_samples, scale_factor, sample_rate, start_time, batch_begin = 0L, batch_end = 0L, verbose = FALSE, debug = FALSE, impute_zeroes = FALSE) {
+    .Call('_read_gt3x_parseGT3X', PACKAGE = 'read.gt3x', filename, max_samples, scale_factor, sample_rate, start_time, batch_begin, batch_end, verbose, debug, impute_zeroes)
 }
 
 #' Parse activity samples from a NHANES-GT3X file

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -14,8 +14,8 @@ activityAsDataFrame <- function(m, time_index, start_time, divider) {
 #' @param sample_rate sampling rate for activity samples.
 #' @param start_time starting time of the sample recording.
 #' @param use_batching whether to use batching or not (false by default)
-#' @param batch_begin first record to include in this batch
-#' @param batch_end last record to include in this batch
+#' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
+#' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 #' @param verbose Print the parameters from the log.bin file and other messages?
 #' @param impute_zeroes Impute zeros in case there are missingness?
 #' @param debug Print information for every activity second

--- a/man/parseGT3X.Rd
+++ b/man/parseGT3X.Rd
@@ -32,9 +32,9 @@ not data is found.}
 
 \item{use_batching}{whether to use batching or not (false by default)}
 
-\item{batch_begin}{first record to include in this batch}
+\item{batch_begin}{first second in time relative to start of raw non-imputed recording to include in this batch}
 
-\item{batch_end}{last record to include in this batch}
+\item{batch_end}{last second in time relative to start of raw non-imputed recording to include in this batch}
 
 \item{verbose}{Print the parameters from the log.bin file and other messages?}
 

--- a/man/parseGT3X.Rd
+++ b/man/parseGT3X.Rd
@@ -10,7 +10,6 @@ parseGT3X(
   scale_factor,
   sample_rate,
   start_time,
-  use_batching = FALSE,
   batch_begin = 0L,
   batch_end = 0L,
   verbose = FALSE,
@@ -29,8 +28,6 @@ not data is found.}
 \item{sample_rate}{sampling rate for activity samples.}
 
 \item{start_time}{starting time of the sample recording.}
-
-\item{use_batching}{whether to use batching or not (false by default)}
 
 \item{batch_begin}{first second in time relative to start of raw non-imputed recording to include in this batch}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -25,8 +25,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // parseGT3X
-NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const bool use_batching, const uint32_t batch_begin, const uint32_t batch_end, const bool verbose, const bool debug, const bool impute_zeroes);
-RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP use_batchingSEXP, SEXP batch_beginSEXP, SEXP batch_endSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
+NumericMatrix parseGT3X(const char* filename, const int max_samples, const double scale_factor, const int sample_rate, const uint32_t start_time, const uint32_t batch_begin, const uint32_t batch_end, const bool verbose, const bool debug, const bool impute_zeroes);
+RcppExport SEXP _read_gt3x_parseGT3X(SEXP filenameSEXP, SEXP max_samplesSEXP, SEXP scale_factorSEXP, SEXP sample_rateSEXP, SEXP start_timeSEXP, SEXP batch_beginSEXP, SEXP batch_endSEXP, SEXP verboseSEXP, SEXP debugSEXP, SEXP impute_zeroesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -35,13 +35,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const double >::type scale_factor(scale_factorSEXP);
     Rcpp::traits::input_parameter< const int >::type sample_rate(sample_rateSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type start_time(start_timeSEXP);
-    Rcpp::traits::input_parameter< const bool >::type use_batching(use_batchingSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type batch_begin(batch_beginSEXP);
     Rcpp::traits::input_parameter< const uint32_t >::type batch_end(batch_endSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type debug(debugSEXP);
     Rcpp::traits::input_parameter< const bool >::type impute_zeroes(impute_zeroesSEXP);
-    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, use_batching, batch_begin, batch_end, verbose, debug, impute_zeroes));
+    rcpp_result_gen = Rcpp::wrap(parseGT3X(filename, max_samples, scale_factor, sample_rate, start_time, batch_begin, batch_end, verbose, debug, impute_zeroes));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -79,7 +78,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_read_gt3x_activityAsDataFrame", (DL_FUNC) &_read_gt3x_activityAsDataFrame, 4},
-    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 11},
+    {"_read_gt3x_parseGT3X", (DL_FUNC) &_read_gt3x_parseGT3X, 10},
     {"_read_gt3x_parseActivityBin", (DL_FUNC) &_read_gt3x_parseActivityBin, 6},
     {"_read_gt3x_parseLuxBin", (DL_FUNC) &_read_gt3x_parseLuxBin, 5},
     {NULL, NULL, 0}

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -319,7 +319,6 @@ int bytes2samplesize(uint8_t& type, uint16_t& bytes) {
 //' @param scale_factor Scale factor for the activity samples.
 //' @param sample_rate sampling rate for activity samples.
 //' @param start_time starting time of the sample recording.
-//' @param use_batching whether to use batching or not (false by default)
 //' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
 //' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 //' @param verbose Print the parameters from the log.bin file and other messages?
@@ -337,7 +336,6 @@ NumericMatrix parseGT3X(const char* filename,
                         const double scale_factor,
                         const int sample_rate,
                         const uint32_t start_time,
-                        const bool use_batching = false,
                         const uint32_t batch_begin = 0,
                         const uint32_t batch_end = 0,
                         const bool verbose = false,
@@ -366,7 +364,7 @@ NumericMatrix parseGT3X(const char* filename,
   bool have_activity2 = false;
   int num_activity = 0;
   int num_activity2 = 0;
-
+  bool use_batching = false;
   int chksum;
 
   if (debug) {
@@ -374,6 +372,10 @@ NumericMatrix parseGT3X(const char* filename,
   }
 
   uint32_t batch_counter = 0;
+
+  if (batch_begin != 0 || batch_end != 0) {
+    use_batching = true;
+  }
 
   while(GT3Xstream) {
 

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -373,7 +373,7 @@ NumericMatrix parseGT3X(const char* filename,
 
   uint32_t batch_counter = 0;
 
-  if (batch_begin != 0 || batch_end != 0) {
+  if (batch_end != 0) {
     use_batching = true;
   }
 

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -320,8 +320,8 @@ int bytes2samplesize(uint8_t& type, uint16_t& bytes) {
 //' @param sample_rate sampling rate for activity samples.
 //' @param start_time starting time of the sample recording.
 //' @param use_batching whether to use batching or not (false by default)
-//' @param batch_begin first record to include in this batch
-//' @param batch_end last record to include in this batch
+//' @param batch_begin first second in time relative to start of raw non-imputed recording to include in this batch
+//' @param batch_end last second in time relative to start of raw non-imputed recording to include in this batch
 //' @param verbose Print the parameters from the log.bin file and other messages?
 //' @param impute_zeroes Impute zeros in case there are missingness?
 //' @param debug Print information for every activity second

--- a/src/parseGT3X.cpp
+++ b/src/parseGT3X.cpp
@@ -373,7 +373,7 @@ NumericMatrix parseGT3X(const char* filename,
 
   uint32_t batch_counter = 0;
 
-  if (batch_end != 0) {
+  if (batch_end > 0) {
     use_batching = true;
   }
 


### PR DESCRIPTION
This PR addresses the main feedback received in https://github.com/THLfi/read.gt3x/pull/40
Once this PR is merged we can copy paste the below message to there.

1. Updates documentation for `parseGT3X.cpp` to clarify that batches are defined in seconds in time relative to start of raw non-imputed recording. This avoids having to use terms like record or sample that would clash with existing code. (this relates to Action points 1 and 2 in the PR 40)
2. Argument `use_batching` has been omitted from `parseGT3X.cpp`. Instead `parseGT3X.cpp` sets `use_batching` as a constant boolean at the top with default value `false`, which is updated to `true` if `batch_end` is larger than zero. (this relates to Action point 3 in the PR 40)

Clarification for why I did not do two other suggestions:

3. I have not incorporated the suggestion by John to let the maximum of `batch_end` line up with `get_n_samples` because `get_n_samples` includes time gaps which is not compatible with `batch_end` which excludes time gaps.
4. Instead of `batch_end = Inf` I now use `batch_end = 0`, because batch_end is an unsigned 32 integer, which does not allow for `Inf` value assignment. Therefore, using 0 as default seems most straightforward.